### PR TITLE
Turn-aware export for single and multi-turn tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ Changelog
   - File naming includes task title: `<taskId>/<version>/<slug(taskTitle)>__<version>.{md,json}` and JSON embeds `taskTitle`
   - Fixed transient postMessage origin mismatch during panel bootstrap
   - Repo cleanup: removed non‑extension files, added this README
+Turn Detection
+- The content script scans the left timeline for stacked prompt bubbles (div.flex.flex-col.gap-4) that are visible in the viewport.
+- For each bubble we look for a prompt header and the set of "Version N" buttons rendered by the task header bar.
+- A bubble is considered a turn when either the prompt text is present (even without the legacy NODE: prefix) or any Version buttons exist; we fall back to synthetic labels (Turn N) and keys when needed.
+- The active turn is picked by comparing each turn bubble's center to the viewport center; the closest visible turn becomes the scope for capture.
+- When multiple versions exist inside the turn, we iterate each button in place, capturing diffs/report/logs before restoring the original selection.


### PR DESCRIPTION
## Summary
- capture the active turn closest to the viewport and scope all sections within that DOM subtree
- iterate any "Version N" buttons inside the active turn to collect per-version diffs, reports, and logs
- fall back to prompt text heuristics so single-version follow-ups without legacy NODE headers still register as turns

## Testing
- manual / Extension: export from task_e_68dbf2249eec83208fc8e2b3b3d0a0fd turn 2 version 1
- manual / Extension: export from task_e_68db13b61ee08320921034a3791bf852 turn 3
- manual / Extension: export from task_e_68dbf2401d0c8320a02429de4629c4ea turn 3